### PR TITLE
Revise PHP versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: php
 
 php:
   - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
- HHVM 未來沒辦法執行 composer
  https://hhvm.com/blog/2019/02/11/hhvm-4.0.0.html

- Build job 加上 PHP 7.1 跟 7.2